### PR TITLE
AI: Fix .github/workflows/ai-agent-task.yml 
looks tha

### DIFF
--- a/.github/workflows/ai-agent-task.yml
+++ b/.github/workflows/ai-agent-task.yml
@@ -13,26 +13,35 @@ jobs:
     steps:
       - name: Create AI Agent Task
         run: |
-          # Extract issue information
-          ISSUE_TITLE="${{ github.event.issue.title }}"
-          ISSUE_BODY="${{ github.event.issue.body }}"
-          ISSUE_URL="${{ github.event.issue.html_url }}"
+          # Extract issue information and escape for JSON
+          ISSUE_TITLE=$(printf '%s' '${{ github.event.issue.title }}' | jq -Rs .)
+          ISSUE_BODY=$(printf '%s' '${{ github.event.issue.body }}' | jq -Rs .)
+          ISSUE_URL=$(printf '%s' '${{ github.event.issue.html_url }}' | jq -Rs .)
 
-          # Combine title and body for the prompt
-          PROMPT="Issue: $ISSUE_TITLE
+          # Construct the prompt
+          PROMPT_TEXT="Issue: ${{ github.event.issue.title }}
 
-          $ISSUE_BODY
+          ${{ github.event.issue.body }}
 
-          Issue URL: $ISSUE_URL"
+          Issue URL: ${{ github.event.issue.html_url }}"
+
+          # Escape the entire prompt for JSON
+          PROMPT_ESCAPED=$(printf '%s' "$PROMPT_TEXT" | jq -Rs .)
+
+          # Create JSON payload
+          JSON_PAYLOAD=$(cat <<EOF
+{
+  "repo": "${{ github.event.repository.clone_url }}",
+  "prompt": $PROMPT_ESCAPED
+}
+EOF
+)
 
           # Make API call to create task
           response=$(curl -X POST https://coding-agent.smartbyte.pl/api/solve \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.CODING_AGENT_API_KEY }}" \
-            -d "{
-              \"repo\": \"${{ github.event.repository.clone_url }}\",
-              \"prompt\": $(echo "$PROMPT" | jq -Rs .)
-            }" \
+            -d "$JSON_PAYLOAD" \
             -w "HTTP_STATUS:%{http_code}" \
             -s)
 


### PR DESCRIPTION
## Summary

This PR was created by AI Coding Agent.

**Task:** Fix .github/workflows/ai-agent-task.yml 
looks that it has wrong format. Task: Create AI Agent Task. Looks like there is comment issue? 
the failed log of an gh action is:
# Extract issue information
  ISSUE_TITLE="Disable fetch_and_categorize step and comment out starred repos fetching"
  ISSUE_BODY="## Problem
  
  Currently the workflow step and script are fetching starred repos from jakublech account on every run. This should be disabled temporarily to reduce API calls and get more context for repo categorization.
  
  ## Changes Required
  
  ### 1. Comment out step in `.github/workflows/update-awesome-repos.yml`
  Comment out or disable the step that executes `scripts/fetch_and_categorize.py`
  
  ### 2. Comment out starred repos fetching in `scripts/fetch_and_categorize.py`
  Comment out the following section in the main flow:
  
  ```python
  print("[*] Fetching starred repos...")
  starred = fetch_starred_repos()
  print(f"[+] Found {len(starred)} starred repos")
  ```
  
  Set `starred = []` instead to skip fetching from jakublech account, while keeping the `fetch_trending_repos()` and categorization logic intact for future use.
  
  ## Rationale
  
  - Reduces GitHub API usage
  - Allows testing categorization pipeline with alternative data sources
  - Maintains script structure for quick re-enablement when needed
  
  ## Related
  
  Script location: `scripts/fetch_and_categorize.py`
  Workflow location: `.github/workflows/update-awesome-repos.yml`"
  ISSUE_URL="https://github.com/jakublech/awesome-repos/issues/3"
  
  # Combine title and body for the prompt
  PROMPT="Issue: $ISSUE_TITLE
  
  $ISSUE_BODY
  
  Issue URL: $ISSUE_URL"
  
  # Make API call to create task
  response=$(curl -X POST https://coding-agent.smartbyte.pl/api/solve \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer " \
    -d "{
      \"repo\": \"https://github.com/jakublech/awesome-repos.git\",
      \"prompt\": $(echo "$PROMPT" | jq -Rs .)
    }" \
    -w "HTTP_STATUS:%{http_code}" \
    -s)
  
  # Extract HTTP status code
  http_code=$(echo "$response" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
  response_body=$(echo "$response" | sed 's/HTTP_STATUS:[0-9]*$//')
  
  echo "API Response Status: $http_code"
  echo "API Response Body: $response_body"
  
  # Check if request was successful
  if [[ $http_code -ge 200 && $http_code -lt 300 ]]; then
    echo "✅ AI Agent task created successfully"
  else
    echo "❌ Failed to create AI Agent task"
    exit 1
  fi
  shell: /usr/bin/bash -e {0}
/home/runner/work/_temp/4cf0f2c1-7eb6-401b-98ab-099760b28a4e.sh: line 32: .github/workflows/update-awesome-repos.yml: No such file or directory
/home/runner/work/_temp/4cf0f2c1-7eb6-401b-98ab-099760b28a4e.sh: line 32: scripts/fetch_and_categorize.py: No such file or directory
/home/runner/work/_temp/4cf0f2c1-7eb6-401b-98ab-099760b28a4e.sh: line 32: scripts/fetch_and_categorize.py: No such file or directory
/home/runner/work/_temp/4cf0f2c1-7eb6-401b-98ab-099760b28a4e.sh: command substitution: line 33: syntax error near unexpected token `"[*] Fetching starred repos..."'
/home/runner/work/_temp/4cf0f2c1-7eb6-401b-98ab-099760b28a4e.sh: command substitution: line 33: `print("[*] Fetching starred repos...")'
/home/runner/work/_temp/4cf0f2c1-7eb6-401b-98ab-099760b28a4e.sh: line 32: starred: command not found
/home/runner/work/_temp/4cf0f2c1-7eb6-401b-98ab-099760b28a4e.sh: command substitution: line 33: syntax error: unexpected end of file
/home/runner/work/_temp/4cf0f2c1-7eb6-401b-98ab-099760b28a4e.sh: line 32: scripts/fetch_and_categorize.py: No such file or directory
/home/runner/work/_temp/4cf0f2c1-7eb6-401b-98ab-099760b28a4e.sh: line 32: .github/workflows/update-awesome-repos.yml: No such file or directory

**Iterations:** 0

**Files modified:** 1
